### PR TITLE
Fix syntax error in composer.json.default

### DIFF
--- a/composer.json.default
+++ b/composer.json.default
@@ -9,7 +9,7 @@
     "topshelfcraft/environment-label": "^3.1.5",
     "verbb/expanded-singles": "^1.0.7",
     "verbb/element-index-defaults": "^1.0.3",
-    "vlucas/phpdotenv": "^2.4.0"
+    "vlucas/phpdotenv": "^2.4.0",
     "mmikkel/cache-flag": "^1.0.3"
   },
   "autoload": {


### PR DESCRIPTION
The pull request from `sync-baseTemplates` branch was incorrectly merged, leading to a missing comma in composer.json.default.